### PR TITLE
Add index page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,15 +1,15 @@
 <template>
   <img alt="Vue logo" src="./assets/logo.png">
-  <HelloWorld msg="Welcome to Your Vue.js App"/>
+  <Index />
 </template>
 
 <script>
-import HelloWorld from './components/HelloWorld.vue'
+import Index from './components/Index.vue'
 
 export default {
   name: 'App',
   components: {
-    HelloWorld
+    Index
   }
 }
 </script>

--- a/src/components/Index.vue
+++ b/src/components/Index.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="index-page">
+    <div class="top">
+      <h1>Project Reader</h1>
+      <p>This project assists in reading the code.</p>
+    </div>
+    <div class="middle">
+      <div class="left">
+        <p>File browsing component goes here</p>
+      </div>
+      <div class="center">
+        <p>Content of the selected file goes here</p>
+      </div>
+      <div class="right">
+        <p>Content returned by the server goes here</p>
+      </div>
+    </div>
+    <div class="bottom">
+      <p>Common website footer information goes here</p>
+    </div>
+  </div>
+</template>
+
+<script>
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'Index',
+  components: {
+    // Add components for file browsing and content display here
+  }
+});
+</script>
+
+<style scoped>
+.index-page {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.top {
+  flex: 0 1 auto;
+  padding: 20px;
+  background-color: #f5f5f5;
+  text-align: center;
+}
+
+.middle {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: row;
+}
+
+.left, .center, .right {
+  flex: 1;
+  padding: 20px;
+  border: 1px solid #ddd;
+}
+
+.bottom {
+  flex: 0 1 auto;
+  padding: 20px;
+  background-color: #f5f5f5;
+  text-align: center;
+}
+</style>

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="main-page">
+    <div class="top">
+      <h1>Project Reader</h1>
+      <p>This project assists in reading the code.</p>
+    </div>
+    <div class="middle">
+      <div class="left">
+        <p>File browsing component goes here</p>
+      </div>
+      <div class="center">
+        <p>Content of the selected file goes here</p>
+      </div>
+      <div class="right">
+        <p>Content returned by the server goes here</p>
+      </div>
+    </div>
+    <div class="bottom">
+      <p>Common website footer information goes here</p>
+    </div>
+  </div>
+</template>
+
+<script>
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'MainPage',
+  components: {
+    // Add components for file browsing and content display here
+  }
+});
+</script>
+
+<style scoped>
+.main-page {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.top {
+  flex: 0 1 auto;
+  padding: 20px;
+  background-color: #f5f5f5;
+  text-align: center;
+}
+
+.middle {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: row;
+}
+
+.left, .center, .right {
+  flex: 1;
+  padding: 20px;
+  border: 1px solid #ddd;
+}
+
+.bottom {
+  flex: 0 1 auto;
+  padding: 20px;
+  background-color: #f5f5f5;
+  text-align: center;
+}
+</style>


### PR DESCRIPTION
Fixes #2

Add main page component and update App.vue to include it.

* **Add `Index.vue` component**
  - Create a new Vue component named `Index`
  - Add a template with three sections: top, middle, and bottom
  - Implement the middle section with left, center, and right parts
  - Add a script section defining the component
  - Add a style section for the component

* **Update `App.vue`**
  - Import the `Index` component
  - Replace the `HelloWorld` component with the `Index` component in the template

